### PR TITLE
Callbacks

### DIFF
--- a/src/menu/mod.rs
+++ b/src/menu/mod.rs
@@ -68,7 +68,7 @@ fn settings_menu(mut zones: u32, mut miners: u32) -> (u32, u32) {
                     }
                     1 => {
                         print!("Insert new miners: ");
-                        io::stdout().flush();
+                        io::stdout().flush().expect("Error flushing stdout.");
                         let new_miners: Result<u32, ParseIntError> = utils::read_integer();
                         if new_miners.is_ok() {
                             miners = new_miners.unwrap()
@@ -78,7 +78,7 @@ fn settings_menu(mut zones: u32, mut miners: u32) -> (u32, u32) {
                     },
                     2 => {
                         print!("Insert new zones: ");
-                        io::stdout().flush();
+                        io::stdout().flush().expect("Error flushing stdout.");
                         let new_zones: Result<u32, ParseIntError> = utils::read_integer();
                         if new_zones.is_ok() {
                             zones = new_zones.unwrap()

--- a/src/model/communication.rs
+++ b/src/model/communication.rs
@@ -4,6 +4,7 @@ use crate::model::miner::MinerId;
 
 pub type  RoundResults = (MinerId,Gold);
 
+#[derive(Debug, Clone)]
 pub enum MiningMessage {
     Start(MapSection),
     Stop,

--- a/src/model/foreman.rs
+++ b/src/model/foreman.rs
@@ -53,14 +53,18 @@ impl Foreman {
             println!("Yo' filthy rats! Go find me some gold in Section {}", section.1);
 
             // TODO: Check errors when sending messages.
-            self.miners_channels.values()
-                .for_each(|miner_channel| miner_channel.send(Start(*section)).check_sending());
+            //self.miners_channels.values()
+                //.for_each(|miner_channel| miner_channel.send(Start(*section)).check_sending());
+            self.miners_channels.iter()
+                .for_each(|(id, channel)| channel.checked_send(Start(*section), Foreman::send_callback(*id)));
 
             self.wait();
 
             // TODO: Check errors when sending message.
-            self.miners_channels.values()
-                .map(|miner_channel| miner_channel.send(Stop).check_sending());
+            //self.miners_channels.values()
+                //.map(|miner_channel| miner_channel.send(Stop).check_sending());
+            self.miners_channels.iter()
+                .for_each(|(id, channel)| channel.checked_send(Stop, Foreman::send_callback(*id)));
         }
     }
 
@@ -71,10 +75,8 @@ impl Foreman {
         io::stdin().read_line(&mut buffer).expect("Failed to read from stdin.");
     }
 
-    fn send_callback(miner_id: MinerId, message: MiningMessage) -> &dyn Fn() -> () {
-        return {
-            println!("Error sending {} to miner {}", message, miner_id);
-        }
+    fn send_callback(miner_id: MinerId) -> impl FnOnce(MiningMessage) {
+        move |message: MiningMessage| { println!("Error sending {:?} to miner {}", message, miner_id) }
     }
 
 }

--- a/src/model/foreman.rs
+++ b/src/model/foreman.rs
@@ -52,19 +52,23 @@ impl Foreman {
         for section in &self.sections {
             println!("Yo' filthy rats! Go find me some gold in Section {}", section.1);
 
-            // TODO: Check errors when sending messages.
-            //self.miners_channels.values()
-                //.for_each(|miner_channel| miner_channel.send(Start(*section)).check_sending());
             self.miners_channels.iter()
-                .for_each(|(id, channel)| channel.checked_send(Start(*section), Foreman::send_callback(*id)));
+                .for_each(|(id, channel)|
+                    channel.checked_send(
+                        Start(*section),
+                        Foreman::send_callback(*id),
+                    )
+                );
 
             self.wait();
 
-            // TODO: Check errors when sending message.
-            //self.miners_channels.values()
-                //.map(|miner_channel| miner_channel.send(Stop).check_sending());
             self.miners_channels.iter()
-                .for_each(|(id, channel)| channel.checked_send(Stop, Foreman::send_callback(*id)));
+                .for_each(|(id, channel)|
+                    channel.checked_send(
+                        Stop,
+                        Foreman::send_callback(*id),
+                    )
+                );
         }
     }
 
@@ -76,7 +80,7 @@ impl Foreman {
     }
 
     fn send_callback(miner_id: MinerId) -> impl FnOnce(MiningMessage) {
+        // TODO: Implement a log for errors.
         move |message: MiningMessage| { println!("Error sending {:?} to miner {}", message, miner_id) }
     }
-
 }

--- a/src/model/foreman.rs
+++ b/src/model/foreman.rs
@@ -19,7 +19,7 @@ pub type MinerId = i32;
 pub struct Foreman {
     miners: Vec<Miner>,
     sections: Vec<MapSection>,
-    miners_channels: HashMap<MinerId, Sender<MiningMessage>>,
+    miners_channels: HashMap<MinerId, Sender<MiningMessage>>
 }
 
 impl Foreman {
@@ -34,7 +34,7 @@ impl Foreman {
         Foreman {
             miners: Vec::new(),
             sections: region_sections,
-            miners_channels: HashMap::new(),
+            miners_channels: HashMap::new()
         }
     }
 
@@ -56,7 +56,7 @@ impl Foreman {
                 .for_each(|(id, channel)|
                     channel.checked_send(
                         Start(*section),
-                        Foreman::send_callback(*id),
+                        Foreman::send_callback(*id)
                     )
                 );
 
@@ -66,7 +66,7 @@ impl Foreman {
                 .for_each(|(id, channel)|
                     channel.checked_send(
                         Stop,
-                        Foreman::send_callback(*id),
+                        Foreman::send_callback(*id)
                     )
                 );
         }

--- a/src/model/foreman.rs
+++ b/src/model/foreman.rs
@@ -4,9 +4,11 @@ use std::sync::mpsc::Sender;
 use std::collections::HashMap;
 
 extern crate rand;
+
 use rand::Rng;
 use rand::prelude::ThreadRng;
 
+use crate::model::utils::CheckedSend;
 use crate::model::miner::Miner;
 use crate::model::map::MapSection;
 use crate::model::communication::MiningMessage;
@@ -17,11 +19,10 @@ pub type MinerId = i32;
 pub struct Foreman {
     miners: Vec<Miner>,
     sections: Vec<MapSection>,
-    miners_channels: HashMap<MinerId, Sender<MiningMessage>>
+    miners_channels: HashMap<MinerId, Sender<MiningMessage>>,
 }
 
 impl Foreman {
-
     pub fn new(sections: i32) -> Foreman {
         // Generating sections randomly.
         let mut random_generator: ThreadRng = rand::thread_rng();
@@ -33,9 +34,8 @@ impl Foreman {
         Foreman {
             miners: Vec::new(),
             sections: region_sections,
-            miners_channels: HashMap::new()
+            miners_channels: HashMap::new(),
         }
-
     }
 
     pub fn hire_miners(&mut self, miners: i32) {
@@ -54,13 +54,13 @@ impl Foreman {
 
             // TODO: Check errors when sending messages.
             self.miners_channels.values()
-                .map(|miner_channel| miner_channel.send(Start(*section)));
+                .for_each(|miner_channel| miner_channel.send(Start(*section)).check_sending());
 
             self.wait();
 
             // TODO: Check errors when sending message.
             self.miners_channels.values()
-                .map(|miner_channel| miner_channel.send(Stop));
+                .map(|miner_channel| miner_channel.send(Stop).check_sending());
         }
     }
 
@@ -69,6 +69,12 @@ impl Foreman {
         io::stdout().flush().expect("Error flushing stdout.");
         let mut buffer = String::new();
         io::stdin().read_line(&mut buffer).expect("Failed to read from stdin.");
+    }
+
+    fn send_callback(miner_id: MinerId, message: MiningMessage) -> &dyn Fn() -> () {
+        return {
+            println!("Error sending {} to miner {}", message, miner_id);
+        }
     }
 
 }

--- a/src/model/miner.rs
+++ b/src/model/miner.rs
@@ -71,8 +71,9 @@ impl Miner {
             .for_each(|(id, channel)|
                 channel.checked_send(
                     ResultsNotification((self.miner_id, self.round.gold_dug)),
-                    Miner::send_callback(*id),
-                ));
+                    Miner::send_callback(*id)
+                )
+            );
     }
 
     fn save_result(&mut self, (id, gold): RoundResults) { self.round.results_received.insert(id, gold); }

--- a/src/model/miner.rs
+++ b/src/model/miner.rs
@@ -7,6 +7,8 @@ use std::iter;
 extern crate rand;
 
 use rand::Rng;
+
+use crate::model::utils::CheckedSend;
 use crate::model::map::{Gold, SectionProbability};
 use crate::model::communication::MiningMessage;
 use crate::model::communication::RoundResults;
@@ -65,13 +67,15 @@ impl Miner {
 
     fn stop_mining(&mut self) {
         // TODO: Check errors when sending message.
-        self.adjacent_miners.values()
-            .map(|miner| miner.send(ResultsNotification((self.miner_id, self.round.gold_dug))));
+        self.adjacent_miners.iter()
+            .for_each(|(id, channel)|
+                channel.checked_send(
+                    ResultsNotification((self.miner_id, self.round.gold_dug)),
+                    Miner::send_callback(*id),
+                ));
     }
 
-    fn save_result(&mut self, (id, gold): RoundResults) {
-        self.round.results_received.insert(id, gold);
-    }
+    fn save_result(&mut self, (id, gold): RoundResults) { self.round.results_received.insert(id, gold); }
 
     fn remove_miner(&mut self, id: MinerId) {
         self.adjacent_miners.remove(&id);
@@ -79,6 +83,10 @@ impl Miner {
 
     fn receive_gold(&mut self, gold: Gold) {
         self.gold_total += gold;
+    }
+
+    fn send_callback(miner_id: MinerId) -> impl FnOnce(MiningMessage) {
+        move |message: MiningMessage| { println!("Error sending {:?} to miner {}", message, miner_id) }
     }
 
     pub fn work(&mut self) {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,3 +2,4 @@ pub mod foreman;
 pub mod miner;
 pub mod communication;
 pub mod map;
+pub mod utils;

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -1,11 +1,12 @@
 use std::sync::mpsc::Sender;
 
-pub trait CheckedSend {
-    fn checked_send<T>(self, message: T, callback: &dyn Fn() -> ()) -> ();
+pub trait CheckedSend<T: Clone> {
+    fn checked_send(&self, message: T, callback: impl FnOnce(T)) -> ();
 }
 
-impl CheckedSend for Sender<T> {
-    fn checked_send(self, message: T, callback: &dyn Fn() -> ()) -> () {
-        if self.send(message).is_err() { callback() }
+impl<T: Clone> CheckedSend<T> for Sender<T> {
+    fn checked_send(&self, message: T, callback: impl FnOnce(T)) -> () {
+        let error_message = message.clone();
+        if self.send(message).is_err() { callback(error_message) }
     }
 }

--- a/src/model/utils.rs
+++ b/src/model/utils.rs
@@ -1,0 +1,11 @@
+use std::sync::mpsc::Sender;
+
+pub trait CheckedSend {
+    fn checked_send<T>(self, message: T, callback: &dyn Fn() -> ()) -> ();
+}
+
+impl CheckedSend for Sender<T> {
+    fn checked_send(self, message: T, callback: &dyn Fn() -> ()) -> () {
+        if self.send(message).is_err() { callback() }
+    }
+}


### PR DESCRIPTION
Cambié el **.map** por un **.for_each** a la hora de enviar los mensajes (el map no se ejecuta si después no evaluas el resultado). Esto generó la necesidad de empezar a interpretar el result que devuelve el send, lo que me hizo hacer un CheckedSend con callbacks y de golpe en el proyecto aparecieron extension functions, generics, callbacks, covarianza y un montón de cosas locas.